### PR TITLE
Add dynamo table for test.

### DIFF
--- a/terraform/delete-test.tf
+++ b/terraform/delete-test.tf
@@ -1,0 +1,10 @@
+resource "aws_dynamodb_table" "test_table" {
+  name = "test_table_for_deletion"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key = "pk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+}


### PR DESCRIPTION
A quick basic DynamoDB table, to test what happens if we manually delete a terraform-managed DynamoDB table.